### PR TITLE
before_actionの設定 fixed #32

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
+
+  private
+  
+  def authenticate_user!
+    unless user_signed_in?
+      redirect_to user_line_omniauth_authorize_path
+    end
+  end
 end

--- a/app/controllers/poses_controller.rb
+++ b/app/controllers/poses_controller.rb
@@ -1,4 +1,6 @@
 class PosesController < ApplicationController
+  skip_before_action :authenticate_user! , only: %i[random show]
+
   def random
     @pose = Pose.order("RANDOM()").first
     # binding.pry

--- a/app/controllers/staticpages_controller.rb
+++ b/app/controllers/staticpages_controller.rb
@@ -1,2 +1,3 @@
 class StaticpagesController < ApplicationController
+  skip_before_action :authenticate_user!
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,7 +1,9 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+
   def line; basic_action end
 
   private
+  
   def basic_action
     @omniauth = request.env["omniauth.auth"]
     if @omniauth.present?

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,4 +1,6 @@
 class Users::SessionsController < Devise::SessionsController
+  skip_before_action :authenticate_user! , only: %i[new]
+
   def new 
     redirect_to user_line_omniauth_authorize_path
   end
@@ -6,7 +8,7 @@ class Users::SessionsController < Devise::SessionsController
   def destroy
     #logout
     sign_out(current_user)
-    redirect_to root_path, status: :see_other, notice: "ログアウトしました"
+    redirect_to root_path, status: :see_other, data: { turbo_method: :delete, turbo_confirm: "ログアウトしました" }
   end
 end
 # 追加

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,14 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     omniauth_callbacks: 'users/omniauth_callbacks',
-    # sessions: 'users/sessions'ここLINEログイン
+    sessions: 'users/sessions'#ここLINEログイン
     #omniauth_callbacks: "omniauth_callbacks"
   }
   devise_scope :user do
-    delete 'logout', to: 'users/sessions#destroy'
+    delete 'logout', to: 'devise/sessions#destroy'
   end
   # 追加
-  # get 'users/auth/line', to: redirect('/users/auth/line')ここLINEログイン
+  get 'users/auth/line', to: redirect('/users/auth/line')#ここLINEログイン
   
   root 'staticpages#top'
   resources :poses, only: [:show]


### PR DESCRIPTION
## before_actionの設定
ログイン前後での認証確認を設定

### やったこと
- [x] application_controllerにbefore_action :authenticate_user!設定
- [x] ログイン状況によるヘッダーの出しわけ