### PR TITLE
カレンダー作成/view(show) closed #73

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -11,9 +11,7 @@ class DiariesController < ApplicationController
   def create
     
     @diary = current_user.diaries.build(diary_params)
-    
-    Rails.logger.debug params.inspect 
-    
+        
     if @diary.save
       redirect_to diaries_path, success: "記録しました"
     else
@@ -26,6 +24,10 @@ class DiariesController < ApplicationController
     @diaries = current_user.diaries
   end
 
+  def show
+    @diary = Diary.find(params[:id])
+  end
+  
   private
 
   def set_pose

--- a/app/helpers/diaries_helper.rb
+++ b/app/helpers/diaries_helper.rb
@@ -1,0 +1,25 @@
+module DiariesHelper
+  def enum_radio_buttons(form, field, enum_values)
+    enum_values.keys.map do |key|
+      content_tag(:div, class: 'form-check form-check-inline') do
+        form.radio_button(field, key, class: 'form-check-input') +
+        form.label("#{field}_#{key}", class: 'form-check-label fs-3') do
+          enum_icon(key)
+        end
+      end
+    end.join.html_safe
+  end
+
+  def enum_icon(key)
+    case key
+    when 'excellent'
+      content_tag(:i, '', class: 'bi bi-emoji-laughing fs-3')
+    when 'good'
+      content_tag(:i, '', class: 'bi bi-emoji-smile fs-3')
+    when 'poor'
+      content_tag(:i, '', class: 'bi bi-emoji-dizzy fs-3')
+    else
+      ''
+    end
+  end
+end

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -1,89 +1,45 @@
-<%= form_with model: @diary, local: true, class: 'container mt-4' do |form| %>
+<%= form_with(model: @diary, local: true, class: 'container mt-4') do |form| %>
   <%= form.hidden_field :pose_id, value: @pose.id %>
 
   <div class="mb-3 row">
-    <%= form.label :date, class: 'form-label col-sm-3 col-form-label' %>
+    <%= form.label :date, class: 'form-label col-sm-2 col-form-label' %>
     <div class="col-sm-9">
-      <%= form.text_field :date, value: @diary.date, readonly: true, class: 'form-control-plaintext' %>
+      <%= form.text_field :date, value: @diary.date, readonly: true, class: 'form-control-plaintext fs-5' %>
     </div>
   </div>
 
   <div class="mb-3 row">
-    <%= form.label :pose, class: 'form-label col-sm-3 col-form-label' %>
+    <label class="form-label col-sm-2 col-form-label">ポーズ名</label>
     <div class="col-sm-9">
-      <%= form.text_field :pose_name, value: @pose.japanese_name, readonly: true, class: 'form-control-plaintext' %>
+      <div class="fs-5 form-control-plaintext"><%= @pose.japanese_name %></div>
     </div>
   </div>
 
   <div class="mb-3">
     <%= form.label :compatibility, 'ポーズとの相性', class: 'form-label' %>
     <div class="d-flex justify-content-start flex-wrap ms-3 gap-3">
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :compatibility, 'excellent', class: 'form-check-input' %>
-        <%= form.label :compatibility_excellent, '◎', class: 'form-check-label fs-3' %>
-      </div>
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :compatibility, 'good', class: 'form-check-input' %>
-        <%= form.label :compatibility_good, '〇', class: 'form-check-label fs-3' %>
-      </div>
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :compatibility, 'poor', class: 'form-check-input' %>
-        <%= form.label :compatibility_poor, '×', class: 'form-check-label fs-3' %>
-      </div>
+      <%= enum_radio_buttons(form, :compatibility, Diary.compatibilities) %>
     </div>
   </div>
 
   <div class="mb-3">
     <%= form.label :condition, '体調', class: 'form-label' %>
     <div class="d-flex justify-content-start flex-wrap ms-3 gap-3">
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :condition, 'excellent', class: 'form-check-input' %>
-        <%= form.label :condition_excellent, '◎', class: 'form-check-label fs-3' %>
-      </div>
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :condition, 'good', class: 'form-check-input' %>
-        <%= form.label :condition_good, '〇', class: 'form-check-label fs-3' %>
-      </div>
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :condition, 'poor', class: 'form-check-input' %>
-        <%= form.label :condition_poor, '×', class: 'form-check-label fs-3' %>
-      </div>
+      <%= enum_radio_buttons(form, :condition, Diary.conditions) %>
     </div>
   </div>
 
   <div class="mb-3">
     <%= form.label :feeling, '気分', class: 'form-label' %>
     <div class="d-flex justify-content-start flex-wrap ms-3 gap-3">
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :feeling, 'excellent', class: 'form-check-input' %>
-        <%= form.label :feeling_excellent, '◎', class: 'form-check-label fs-3' %>
-      </div>
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :feeling, 'good', class: 'form-check-input' %>
-        <%= form.label :feeling_good, '〇', class: 'form-check-label fs-3' %>
-      </div>
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :feeling, 'poor', class: 'form-check-input' %>
-        <%= form.label :feeling_poor, '×', class: 'form-check-label fs-3' %>
-      </div>
+      <%= enum_radio_buttons(form, :feeling, Diary.feelings) %>
     </div>
   </div>
 
   <div class="mb-3">
     <%= form.label :sleep, '睡眠', class: 'form-label' %>
     <div class="d-flex justify-content-start flex-wrap ms-3 gap-3">
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :sleep, 'excellent', class: 'form-check-input' %>
-        <%= form.label :sleep_excellent, '◎', class: 'form-check-label fs-3' %>
-      </div>
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :sleep, 'good', class: 'form-check-input' %>
-        <%= form.label :sleep_good, '〇', class: 'form-check-label fs-3' %>
-      </div>
-      <div class="form-check form-check-inline">
-        <%= form.radio_button :sleep, 'poor', class: 'form-check-input' %>
-        <%= form.label :sleep_poor, '×', class: 'form-check-label fs-3' %>
-      </div>
+      <%= enum_radio_buttons(form, :sleep, Diary.sleeps) %>
     </div>
   </div>
 
@@ -103,8 +59,6 @@
   </div>
 
   <div class="container d-flex flex-column align-items-center">
-
-    <%= form.submit '記録する', class: 'btn btn-outline-secondary btn-lg' %>
+    <%= form.submit '記録する', class: 'btn btn-outline-secondary btn-lg', data: {turbo: false} %>
   </div>
 <% end %>
-

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -1,0 +1,74 @@
+<div class="container pt-5">
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2">
+      <h1 class="text-center"><%= @diary.date.strftime('%Y-%m-%d') %></h1>
+      <article class="card">
+        <div class="card-body">
+          <div class="row mb-4">
+            <div class="col-md-3">
+              <strong>行ったポーズ</strong>
+            </div>
+            <div class="col-md-9 fs-4 ms-5">
+              <p class="form-control-plaintext"><%= @diary.pose.japanese_name %></p>
+            </div>
+          </div>
+
+          <div class="row mb-3">
+            <div class="col">
+              <strong class="me-3">ポーズとの相性</strong>
+              <p class="form-control-plaintext ms-5">
+                <%= enum_icon(@diary.compatibility) %>
+              </p>
+            </div>
+            <div class="col">
+              <strong>体調</strong>
+              <p class="form-control-plaintext ms-5">
+                <%= enum_icon(@diary.condition) %>
+              </p>
+            </div>
+          </div>
+
+          <div class="row mb-3">
+            <div class="col">
+              <strong>気分</strong>
+              <p class="form-control-plaintext ms-5">
+                <%= enum_icon(@diary.feeling) %>
+              </p>
+            </div>
+            <div class="col">
+              <strong>睡眠</strong>
+              <div class="form-control-plaintext ms-5">
+                <%= enum_icon(@diary.sleep) %>
+              </p>
+            </div>
+          </div>
+
+          <div class="row mb-3">
+            <div class="col-md-3">
+              <strong>体重</strong>
+            </div>
+            <div class="col-md-9 ms-4">
+              <p class="form-control-plaintext">
+                <% if @diary.weight.present? %>
+                  <%= @diary.weight %>  kg
+                <% end %>
+              </p>
+            </div>
+          </div>
+
+          <div class="row mb-3">
+            <div class="col-md-3">
+              <strong>メモ</strong>
+            </div>
+            <div class="col-md-9 ms-4">
+              <p class="form-control-plaintext"><%= @diary.memo %></p>
+            </div>
+          </div>
+        </div>
+      </article>
+    </div>
+    <div class="container d-flex flex-column align-items-center">
+      <%= link_to 'back', diaries_path, class: 'btn btn-outline-secondary btn-lg' %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## 概要

カレンダーの日付をクリックすると、記録した日記の詳細ページへ遷移

## やったこと

- [x] diaries_controllerのshowアクションの追加
- [x] showページのview作成
- [x] 体調等の程度を示すアイコンを◎から絵文字へ変更
- [x] diaries_helperを作成。体調等の程度と絵文字を定型化し、コードの可視性を向上
- [x] 日記を記録する際に画面が更新されるようturboをオフ(_form.html.erb)

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 記録した日記の確認
 [![Image from Gyazo](https://i.gyazo.com/ef27860f3bdbb78138411578f0b35f63.png)](https://gyazo.com/ef27860f3bdbb78138411578f0b35f63)

## できなくなること（ユーザ目線）

* なし

## 動作確認

* ブラウザにて確認

## 関連Issue
#34 #72 

## その他

* 今回のissue内容とは直接関係ないが、form送信時にpose_nameを送信することによるUnpermitted parameterが発生していたためデータを送信しないよう修正。

  before
 [![Image from Gyazo](https://i.gyazo.com/51fc824f6195410b1ef884c4e92a6256.png)](https://gyazo.com/51fc824f6195410b1ef884c4e92a6256)

  after
  [![Image from Gyazo](https://i.gyazo.com/d659796e0ed4547e23dba54f75cd9252.png)](https://gyazo.com/d659796e0ed4547e23dba54f75cd9252)
