### PR TITLE
日記登録時のバグ解消 closed #83

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -6,16 +6,20 @@ class DiariesController < ApplicationController
   def new
     #binding.pry
     @diary = Diary.new(pose_id: @pose.id, date:Date.today)
+    #@pose = Pose.find(params[:pose_id])
   end
 
   def create
     
     @diary = current_user.diaries.build(diary_params)
+    @pose = Pose.find_by(id: diary_params[:pose_id])
         
     if @diary.save
-      redirect_to diaries_path, success: "記録しました"
+      redirect_to diaries_path, notice: "記録しました"
     else
-      flash.now[:danger] = "記録できませんでした"
+      flash.now[:alert] = "記録できませんでした"
+      
+      Rails.logger.debug(@diary.errors.full_messages.join(", "))
       render :new
     end
   end
@@ -36,7 +40,7 @@ class DiariesController < ApplicationController
 
   def check_register_diary
     if Diary.where(user:current_user, date:Time.zone.today).exists?
-      redirect_to diaries_path, notice:"今日の頑張りは登録してあります！また明日も頑張りましょう！"
+      redirect_to diaries_path, notice:"今日のがんばりは登録してあります！また明日も頑張りましょう！"
     end
   end
 

--- a/app/views/diaries/_calendar.html.erb
+++ b/app/views/diaries/_calendar.html.erb
@@ -1,4 +1,4 @@
-<%= month_calendar(attribute: :created_at, events: @diaries) do |date, diaries| %>
+  <%= month_calendar(attribute: :date, events: @diaries) do |date, diaries| %>
     <%= date.day %>
 
     <% diaries.each do |diary| %>
@@ -9,3 +9,4 @@
       </div>
     <% end %>
   <% end %>
+  


### PR DESCRIPTION
## 概要

日記登録に失敗した際の
ActionView::Template::Error (undefined method `japanese_name' for nil:NilClass):となるエラーを解消

## やったこと

- [x] poseオブジェクトが渡せていないことがエラーの原因であったためdiaries_controllerのcreateアクションに ` @pose = Pose.find_by(id: diary_params[:pose_id]) `を追加
- [x] カレンダーに記載される日記の日付がずれるため、` month_calendar `の` attribute `を` created_at `から`date`へ変更

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 日記が登録できる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* ブラウザにて確認

## 関連Issue

## その他

