### PR TITLE
日記詳細画面の編集/controller closed #15

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -32,6 +32,20 @@ class DiariesController < ApplicationController
     @diary = Diary.find(params[:id])
   end
   
+  def edit
+    @diary = current_user.diaries.find(params[:id])
+  end
+
+  def update
+    @diary = current_user.diaries.find(params[:id])
+    if @diary.update(diary_params)
+      redirect_to diary_path(diary), notice:"編集しました"
+    else
+      flash.now[:alert] = "編集できませんでした"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_pose

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -68,7 +68,9 @@
       </article>
     </div>
     <div class="container d-flex flex-column align-items-center">
-      <%= link_to 'back', diaries_path, class: 'btn btn-outline-secondary btn-lg' %>
+      <%= link_to '戻る', diaries_path, class: 'btn btn-outline-secondary btn-lg' %>
+      <%= link_to '編集する', edit_diary_path, class: 'btn btn-outline-secondary btn-lg' %>
+
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,7 @@ Rails.application.routes.draw do
   root 'staticpages#top'
   
   devise_for :users, controllers: {
-    omniauth_callbacks: 'users/omniauth_callbacks',
-    #sessions: 'users/sessions'#ここLINEログイン
-    #omniauth_callbacks: "omniauth_callbacks"
+    omniauth_callbacks: 'users/omniauth_callbacks'
   }
   devise_scope :user do
     delete 'logout', to: 'users/sessions#destroy'
@@ -15,7 +13,7 @@ Rails.application.routes.draw do
   resources :poses, only: [:show]
   get 'pose/random', to: 'poses#random', as: 'random_pose'
 
-  resources :diaries, only: %i[new create index show]
+  resources :diaries, only: %i[new create index show edit update]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## 概要

日記の編集ができるようにするためcontrollerの実装を行った

## やったこと

  - [x] editアクションの追加
  - [x] updateアクションの追加
  - [x] routingの設定
  - [x] diary/showに編集ページへ遷移する編集ボタンの設置

## やらないこと

* viewの実装

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* ブラウザにてeditページへ遷移することを確認

## 関連Issue


## その他


