### PR TITLE
Line通知設定ボタンの設置

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -25,6 +25,7 @@ class DiariesController < ApplicationController
 
   def index
     @diaries = current_user.diaries
+    @user=current_user
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,70 +1,14 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[ show edit update destroy ]
+  before_action :set_user, only: [:set_line_notification]
 
-  # GET /users or /users.json
-  def index
-    @users = User.all
-  end
-
-  # GET /users/1 or /users/1.json
-  def show
-  end
-
-  # GET /users/new
-  def new
-    @user = User.new
-  end
-
-  # GET /users/1/edit
-  def edit
-  end
-
-  # POST /users or /users.json
-  def create
-    @user = User.new(user_params)
-
-    respond_to do |format|
-      if @user.save
-        format.html { redirect_to user_url(@user), notice: "User was successfully created." }
-        format.json { render :show, status: :created, location: @user }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # PATCH/PUT /users/1 or /users/1.json
-  def update
-    respond_to do |format|
-      if @user.update(user_params)
-        format.html { redirect_to user_url(@user), notice: "User was successfully updated." }
-        format.json { render :show, status: :ok, location: @user }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # DELETE /users/1 or /users/1.json
-  def destroy
-    @user.destroy!
-
-    respond_to do |format|
-      format.html { redirect_to users_url, notice: "User was successfully destroyed." }
-      format.json { head :no_content }
-    end
+  def set_line_notification
+    notification_setting = params[:line_notification] == "1"
+    @user.update(line_notification: notification_setting)
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_user
-      @user = User.find(params[:id])
-    end
 
-    # Only allow a list of trusted parameters through.
-    def user_params
-      params.require(:user).permit(:name)
-    end
+  def set_user
+    @user = current_user
+  end
 end

--- a/app/jobs/send_line_job.rb
+++ b/app/jobs/send_line_job.rb
@@ -4,7 +4,7 @@ class SendLineJob < ApplicationJob
   def perform
     User.find_each do |user|
       # 全ユーザーを対象にリマインダー通知を送信する
-      # next unless user.receive_reminder_notifications
+      next unless user.line_notification
       # ユーザーが通知を受け取る設定になっているかチェック
       # binding.pry
       reminder_message = generate_reminder_message(user)

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,9 +1,15 @@
 <div class="container">
   <div class="row">
-    <div class="col-12 text-center mt-4">
-      <h1>My Diary<i class="bi bi-vector-pen"></i></h1>
+    <div class="col-12 text-center mt-4 mb-3">
+      <h1><%= @user.name %>さんの Diary <i class="bi bi-vector-pen"></i></h1>
     </div>
   </div>
+  <%= form_with url: users_set_line_notification_path, method: :patch, local: true, id: 'line-notification-form' do %>
+    <div class="form-check form-switch form-check-reverse">
+      <%= check_box_tag :line_notification, '1', current_user.line_notification, class: 'form-check-input', id: 'line-toggle', onchange: 'this.form.submit();' %>
+      <%= label_tag :line_notification, '毎朝8時のLINE通知', class: 'form-check-label' %>
+    </div>
+  <% end %>
 
   <div id="diaries_calendar">
     <%= render "calendar", diaries: @diaries %>

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,7 @@ services:
       TZ: Asia/Tokyo
       POSTGRES_PASSWORD: password
     volumes:
-      - postgresql_data:/var/lib/postgresql/date
+      - postgresql_data:/var/lib/postgresql
     ports:
       - 5432:5432
     healthcheck:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
   end
   # LINEログイン
   get 'users/auth/line', to: redirect('/users/auth/line')
-    
+  
+  patch 'users/set_line_notification', to: 'users#set_line_notification'
+      
   resources :poses, only: [:show]
   get 'pose/random', to: 'poses#random', as: 'random_pose'
 

--- a/db/migrate/20240627235111_add_line_notification_to_users.rb
+++ b/db/migrate/20240627235111_add_line_notification_to_users.rb
@@ -1,0 +1,5 @@
+class AddLineNotificationToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :line_notification, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_07_065152) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_27_235111) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_07_065152) do
     t.string "provider"
     t.string "uid"
     t.string "name"
+    t.boolean "line_notification", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要

My DIaryページ(Diaries/index.html) にLINE通知設定スイッチボタン設置

## やったこと

- [x] Usesrテーブルにline_notificationカラム(boolean型)追加
- [x] ルーティング設定
- [x] diaries/indexにてLINE通知設定のスイッチボタン設置
 - スイッチ切替にて即座に通知設定の変更ができる

## やらないこと

- [ ] LINE友達追加表示(別issueにてモーダル表示を検討)

## できるようになること（ユーザ目線）

* LINE通知設定ができる

## できなくなること（ユーザ目線）

* なし

## 動作確認
* Diaryページ
[![Image from Gyazo](https://i.gyazo.com/c797aad259d5436764152eb5d6a11911.png)](https://gyazo.com/c797aad259d5436764152eb5d6a11911)

* コンソールにて通知設定(line_notification)が切り替わっていることを確認

## 関連Issue
#99 

## その他
* users/contorollerは不要のため削除


