### PR TITLE
renderでhostが定義されていないバグを修正

### DIFF
--- a/app/jobs/send_line_job.rb
+++ b/app/jobs/send_line_job.rb
@@ -41,8 +41,8 @@ class SendLineJob < ApplicationJob
 
   def pose_image_url(pose)
     # binding.pry
-    host = Rails.application.config.host
-    ActionController::Base.helpers.asset_url(pose.image, host:host).force_encoding('UTF-8')
+    host = Rails.application.config.host_url
+    ActionController::Base.helpers.asset_url(pose.image, host:host)
   end
 
   def host_url

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,4 +95,5 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
   config.hosts << 'www.yoga-diary-app.com'
+  config.host_url ='https://www.yoga-diary-app.com'
 end

--- a/render.yaml
+++ b/render.yaml
@@ -7,7 +7,7 @@ databases:
 services:
   - type: web
     name: Portfolio
-    env: docker
+    env: ruby
     region: singapore
     buildCommand: "./bin/render-build.sh"
     startCommand: "bundle exec puma -C config/puma.rb"


### PR DESCRIPTION
## 概要

renderでのLINE通知が送信できないバグを処理

## 概要
renderのbackground workerでのhostメソッドが定義されてないエラーが発生。
このためにLINE通知が送信できていない。
```
E, [2024-07-02T00:00:21.317098 #92] ERROR -- : [ActiveJob] [SendLineJob] [b52510f5-68ec-4c8c-b5ff-b9d3752c87f7] 
Error performing SendLineJob (Job ID: b52510f5-68ec-4c8c-b5ff-b9d3752c87f7) from Async(default) in 156.22ms: NoMethodError (undefined method `host' for #<Rails::Application::Configuration:0x0000000000da20>)
/opt/render/project/.gems/ruby/3.2.0/gems/railties-7.1.3.3/lib/rails/railtie/configuration.rb:109:in `method_missing'
/opt/render/project/src/app/jobs/send_line_job.rb:44:in `pose_image_url'
```

## やったこと

- [x] configにhost_urlを定義

