### PR TITLE
renderにてファビコンが読み込まれないバグ対応

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title><%= page_title(yield(:title)) %></title>
-    <%= favicon_link_tag('favicon.icon') %>
+    <%= favicon_link_tag('favicon.icon.png') %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
## 概要

デプロイ先でのファビコンが読み込まれないバグ対応
[![Image from Gyazo](https://i.gyazo.com/4dadc0c267590a0b6cda76ea3ed973a5.png)](https://gyazo.com/4dadc0c267590a0b6cda76ea3ed973a5)

## やったこと

- [x] link_tagの引数を('favicon.icon')から('favicon.icon.png')へ変更

## やらないこと

* なし

## できるようになること（ユーザ目線）

* アプリが表示できる

## できなくなること（ユーザ目線）

* なし

## 動作確認

ローカル環境での動作確認は前回 #130 にて確認済みのため、デプロイ後再度確認予定

## 関連Issue
#130 

## その他


