### PR TITLE
top画のswiperと位置調整　

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -7,7 +7,7 @@
 
   .top-inner-text {
     position: absolute;
-    top: 60%;
+    top: 30%;
     left: 50%;
     transform: translate(-50%, -50%);
     width: 100%;
@@ -21,7 +21,7 @@
   }
   .top-start-botton {
     position: absolute;
-    top: 70%;
+    top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
     
@@ -49,16 +49,17 @@
 }
 
 .swiper-container {
+  position: relative;
+  top: -180px;
   width: 100%;
-  padding: 20px 0;
   overflow: hidden;
 }
 
 .swiper-wrapper {
   display: flex;
   width: 100%;
-  justify-content: center;
   align-items: center;
+  transition-timing-function: linear;
 }
 
 .swiper-slide {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,18 +6,19 @@ import * as bootstrap from "bootstrap"
 import Swiper from 'swiper/bundle';
 import 'swiper/swiper-bundle.css';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('turbo:load', () => {
   const swiperContainer = document.querySelector('.swiper-container');
   if (swiperContainer) {
     const swiper = new Swiper(swiperContainer, {
       slidesPerView: 'auto',
-      spaceBetween: 30,
+      spaceBetween: 20,
       loop: true,
       autoplay: {
-        delay: 2500,
+        delay: 0,
         disableOnInteraction: false,
       },
-      speed: 600,
+      speed: 5000,
+      centeredSlides: true,
     });
   } else {
     console.error('Swiper container not found!');

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -10,7 +10,7 @@
 </div>
 
 <!-- Slider main container -->
-<div class="swiper-container my-5">
+<div class="swiper-container">
   <div class="swiper-wrapper">
     <% @poses.each do |pose| %>
       <div class="swiper-slide">


### PR DESCRIPTION
## 概要

TOP画のswiperの位置調整
swiperが途中で途切れるバグを修正

## やったこと

- [x] cssを修正
- [x] swiperの挙動についてはcssの `justify-content: center;`を削除

## やらないこと

* なし

## できるようになること（ユーザ目線）

* ポーズのイラストがエンドレスで流れるのを確認できる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* before
[![Image from Gyazo](https://i.gyazo.com/b014762053f667d425b860f437c894cc.gif)](https://gyazo.com/b014762053f667d425b860f437c894cc)

* after
[![Image from Gyazo](https://i.gyazo.com/b99b56d170a598957031e320f0a4df13.gif)](https://gyazo.com/b99b56d170a598957031e320f0a4df13)

## 関連Issue
#101 

## その他


