### PR TITLE
エラー表示画面/controller closed #143

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,29 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
 
+  rescue_from StandardError, with: :render_500
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActionController::RoutingError, with: :render_404
+
+  def routing_error
+    raise ActionController::RoutingError, params[:path]
+  end
+
   private
   
   def authenticate_user!
     unless user_signed_in?
       redirect_to user_line_omniauth_authorize_path
     end
+  end
+
+  def render_404(e = nil)
+    logger.info "Rendering 404 error #{e.message}" if e
+    render "errors/404", layout: false, status: :not_found
+  end 
+
+  def render_500(e = nil)
+    logger.info "Rendering 500 error #{e.message}" if e
+    render "errors/500", layout: false, status: :internal_server_error
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,8 +21,10 @@ Rails.application.routes.draw do
 
   # Sidekiq job 管理画面
   require 'sidekiq/web'
-  mount Sidekiq::Web => "/sidekiq"
+  mount Sidekiq::Web => '/sidekiq'
 
+  # エラー画面カスタマイズ
+  match '*path', to: 'application#routing_error', via: :all
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## 概要

404，500エラー表示画面をカスタマイズするためにcontrollerを実装

## やったこと

- [x] application_controller.rbにエラーハンドリング処理を記載
- [x] standardエラーを500エラーとしてキャッチ
- [x] ページが見つからないエラーを404エラーとしてキャッチ

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

ログにてerrorsページがレンダリングされていることを確認
 [![Image from Gyazo](https://i.gyazo.com/4710a072d73e27d37e7d1d1a4c9a577d.png)](https://gyazo.com/4710a072d73e27d37e7d1d1a4c9a577d)

## 関連Issue

## その他

* 
