### PR TITLE
only_one_diary_per_dayメソッドを編集

### DIFF
--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -15,8 +15,9 @@ class Diary < ApplicationRecord
 
   private
   def only_one_diary_per_day
-    if Diary.exists?(user_id: user_id, date: date)
+    if Diary.where(user_id: user_id, date: date).where.not(id: id).exists?
       errors.add(:base, "今日のDiaryは登録してあります！また明日も頑張りましょう！")
     end
+
   end
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -15,13 +15,8 @@ class Diary < ApplicationRecord
 
   private
   def only_one_diary_per_day
-    cache_key = "user_#{user_id}_diary_#{date}"
-    existing_diary = Diary.where(user_id: user_id, date: date).where.not(id: id).first
-  
-    if existing_diary.present?
+    if Diary.exists?(user_id: user_id, date: date)
       errors.add(:base, "今日のDiaryは登録してあります！また明日も頑張りましょう！")
-    else
-      Rails.cache.write(cache_key, true)
     end
   end
 end


### PR DESCRIPTION
## 概要

only_one_diary_per_dayメソッドの不要部分を削除

## やったこと

- [x] cache_keyを削除

```
before
    cache_key = "user_#{user_id}_diary_#{date}"
    existing_diary = Diary.where(user_id: user_id, date: date).where.not(id: id).first

    if existing_diary.present?
      errors.add(:base, "今日のDiaryは登録してあります！また明日も頑張りましょう！")
    else
      Rails.cache.write(cache_key, true)
    end
```
```
after
    if Diary.where(user_id: user_id, date: date).where.not(id: id).exists?
      errors.add(:base, "今日のDiaryは登録してあります！また明日も頑張りましょう！")
    end
```
- キャッシュを使用していたが、同じ日のDiaryを見に行くことは少なく、パフォーマンスに影響が及ぶことは低いと考え，保守がしやすく直感的なコードへ変更

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

[![Image from Gyazo](https://i.gyazo.com/734bcb5006cfa78ff43ed23e2ef198ba.png)](https://gyazo.com/734bcb5006cfa78ff43ed23e2ef198ba)

## 関連Issue
#156 

## その他

* 
