### PR TITLE
タイトル表示が正しく表示されないバグ修正

### DIFF
--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -6,4 +6,9 @@ const application = Application.start()
 application.debug = false
 window.Stimulus   = application
 
-export { application }
+document.addEventListener('turbo:load', () => {
+  const titleElement = document.querySelector('meta[name="title"]');
+  if (titleElement) {
+    document.title = titleElement.content;
+  }
+});


### PR DESCRIPTION
## 概要

タイトルが動的に表示できないバグ対応

## やったこと

- [x] EventListener('turbo:load')にて、ページ遷移が行われたタイミングで、動的にタイトルを読みこむよう記載

## やらないこと

* なし

## できるようになること（ユーザ目線）

* タイトルが動的に表示される

## できなくなること（ユーザ目線）

* なし
## 動作確認

## 関連Issue


## その他


