### PR TITLE
TOPページ以外でのSwiperを読みこむバグ修正

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,26 +1,5 @@
 // Entry point for the build script in your package.json
-console.log('application.js is loaded'); // 追加するログ
+console.log('application.js is loaded'); 
 import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"
-import Swiper from 'swiper/bundle';
-import 'swiper/swiper-bundle.css';
-
-document.addEventListener('turbo:load', () => {
-  const swiperContainer = document.querySelector('.swiper-container');
-  if (swiperContainer) {
-    const swiper = new Swiper(swiperContainer, {
-      slidesPerView: 'auto',
-      spaceBetween: 20,
-      loop: true,
-      autoplay: {
-        delay: 0,
-        disableOnInteraction: false,
-      },
-      speed: 5000,
-      centeredSlides: true,
-    });
-  } else {
-    console.error('Swiper container not found!');
-  }
-});

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import SwiperController from "./swiper_controller"
+application.register("swiper", SwiperController)

--- a/app/javascript/controllers/swiper_controller.js
+++ b/app/javascript/controllers/swiper_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+import Swiper from 'swiper/bundle';
+import 'swiper/swiper-bundle.css';
+
+// Connects to data-controller="swiper"
+export default class extends Controller {
+  connect() {
+    console.log('SwiperController is connected');
+    const swiperContainer = document.querySelector('.swiper-container');
+    if (swiperContainer) {
+      const swiper = new Swiper(swiperContainer, {
+        slidesPerView: 'auto',
+        spaceBetween: 20,
+        loop: true,
+        autoplay: {
+          delay: 0,
+          disableOnInteraction: false,
+        },
+        speed: 5000,
+        centeredSlides: true,
+      });
+    } else {
+      console.error('Swiper container not found!');
+    }
+  }
+}

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -10,15 +10,17 @@
 </div>
 
 <!-- Slider main container -->
-<div class="swiper-container">
-  <div class="swiper-wrapper">
-    <% @poses.each do |pose| %>
-      <div class="swiper-slide">
-        <%= link_to pose_path(pose) do %>
-          <%= image_tag pose.image, class: "card-img-top" %>
-        <% end %>
-      </div>
-    <% end %>
+<div data-controller="swiper">
+  <div class="swiper-container">
+    <div class="swiper-wrapper">
+      <% @poses.each do |pose| %>
+        <div class="swiper-slide">
+          <%= link_to pose_path(pose) do %>
+            <%= image_tag pose.image, class: "card-img-top" %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## 概要

ブラウザの検証ツールにて、TOPページ以外でSwiperを読みこもうとし、コンテナがないというエラーが発生していた。TOPページ以外にSwiperを表示させる意図はないため、TOPのみSwiperを作動するよう修正

[![Image from Gyazo](https://i.gyazo.com/e011a4739cbf7bea099a29d4519d049d.png)](https://gyazo.com/e011a4739cbf7bea099a29d4519d049d)

## やったこと

- [x] swiper_controllerの作成：可読性向上のため
- [x] turbo:loadの削除：ページ遷移するたびにswiperが初期化され、エラーが発生していたと考えられるため

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* ローカル環境にて検証ツールでエラーが出ないことを確認
[![Image from Gyazo](https://i.gyazo.com/4a34d4627cbcbaf2f08689ee197c12da.png)](https://gyazo.com/4a34d4627cbcbaf2f08689ee197c12da)

## 関連Issue


## その他

* なし
