### PR TITLE
レビュー対応 #167

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -32,6 +32,8 @@ jobs:
           gem install bundler
           bundle install
       - name: Set up PostgreSQL
+        env:
+         PGPASSWORD: password
         run: psql -U rails -h localhost -d rails_test -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"      
       - name: Set up database schema
         run: bin/rails db:schema:load

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -32,9 +32,7 @@ jobs:
           gem install bundler
           bundle install
       - name: Set up PostgreSQL
-        run: |
-          sudo apt-get install postgresql-client
-          psql -U rails -h localhost -d rails_test -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"      
+        run: psql -U rails -h localhost -d rails_test -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"      
       - name: Set up database schema
         run: bin/rails db:schema:load
       - name: Run tests

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      # Add or replace dependency steps here
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
@@ -31,11 +30,13 @@ jobs:
       - name: Bundler and gem install
         run: |
           gem install bundler
-          bundle install          
-      # Add or replace database setup steps here
+          bundle install
+      - name: Set up PostgreSQL
+        run: |
+          sudo apt-get install postgresql-client
+          psql -U rails -h localhost -d rails_test -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"      
       - name: Set up database schema
         run: bin/rails db:schema:load
-      # Add or replace test runners here
       - name: Run tests
         run: bundle exec rspec 
 

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -52,6 +52,7 @@ class DiariesController < ApplicationController
 
   def check_register_diary
     return unless Diary.exists?(user: current_user, date: Time.zone.today)
+
     flash[:alert] = '今日のDiaryは登録してあります！また明日も頑張りましょう！'
     redirect_to diaries_path
   end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -9,7 +9,7 @@ class DiariesController < ApplicationController
   end
 
   def show
-    @diary = Diary.find(params[:id])
+    @diary = current_user.diaries.find(params[:id])
   end
 
   def new
@@ -52,7 +52,6 @@ class DiariesController < ApplicationController
 
   def check_register_diary
     return unless Diary.exists?(user: current_user, date: Time.zone.today)
-
     flash[:alert] = '今日のDiaryは登録してあります！また明日も頑張りましょう！'
     redirect_to diaries_path
   end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -14,8 +14,7 @@ class Diary < ApplicationRecord
   private
 
   def only_one_diary_per_day
-    return unless Diary.where(user_id: user_id, date: date).where.not(id: id).exists?
-
+    return unless Diary.where(user_id: user_id, date: date).where.not(uuid: uuid).exists?
     errors.add(:base, '今日のDiaryは登録してあります！また明日も頑張りましょう！')
   end
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -5,6 +5,7 @@ class Diary < ApplicationRecord
   validates :weight, numericality: { greater_than: 0 }, allow_nil: true
   validates :memo, length: { maximum: 150 }
   validate :only_one_diary_per_day
+  validate :register_today
 
   enum compatibility: { excellent: '◎', good: '〇', poor: '×' }, _prefix: true
   enum condition: { excellent: '◎', good: '〇', poor: '×' }, _prefix: true
@@ -15,6 +16,12 @@ class Diary < ApplicationRecord
 
   def only_one_diary_per_day
     return unless Diary.where(user_id: user_id, date: date).where.not(uuid: uuid).exists?
-    errors.add(:base, '今日のDiaryは登録してあります！また明日も頑張りましょう！')
+    errors.add(:base, '今日のDiaryは登録してあります！明日も頑張りましょう！')
+  end
+
+  def register_today
+    if date != Date.today
+      errors.add(:date, '当日分のみ登録できます')
+    end
   end
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -17,7 +17,7 @@ class Diary < ApplicationRecord
   def only_one_diary_per_day
     return unless Diary.where(user_id: user_id, date: date).where.not(uuid: uuid).exists?
 
-    errors.add(:base, '今日のDiaryは登録してあります！明日も頑張りましょう！')
+    errors.add(:base, '今日のDiaryは登録してあります！また明日も頑張りましょう！')
   end
 
   def register_today

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -16,12 +16,13 @@ class Diary < ApplicationRecord
 
   def only_one_diary_per_day
     return unless Diary.where(user_id: user_id, date: date).where.not(uuid: uuid).exists?
+
     errors.add(:base, '今日のDiaryは登録してあります！明日も頑張りましょう！')
   end
 
   def register_today
-    if date != Date.today
-      errors.add(:date, '当日分のみ登録できます')
-    end
+    return unless date != Time.zone.today
+
+    errors.add(:date, '当日分のみ登録できます')
   end
 end

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, @diary.date) %>
 <meta name="title" content="<%= yield(:title) %>">
-<div class="container pt-5">
+<div class="container pt-3">
   <div class="row">
     <div class="col-lg-8 offset-lg-2">
       <h1 class="text-center"><%= @diary.date.strftime('%Y/%m/%d') %></h1>

--- a/db/migrate/20240727095701_add_uuid.rb
+++ b/db/migrate/20240727095701_add_uuid.rb
@@ -1,0 +1,9 @@
+class AddUuid < ActiveRecord::Migration[7.1]
+  def change
+    add_column :diaries, :uuid, :uuid, default: 'gen_random_uuid()', null: false
+    add_index :diaries, :uuid, unique: true
+
+    Diary.reset_column_information 
+    Diary.find_each { |diary| diary.update_column(:uuid, SecureRandom.uuid) }
+  end
+end

--- a/db/migrate/20240727222931_change_diaries_primary_key_to_uuid.rb
+++ b/db/migrate/20240727222931_change_diaries_primary_key_to_uuid.rb
@@ -1,0 +1,6 @@
+class ChangeDiariesPrimaryKeyToUuid < ActiveRecord::Migration[7.1]
+  def change
+     execute 'ALTER TABLE diaries DROP CONSTRAINT diaries_pkey;'
+     execute 'ALTER TABLE diaries ADD PRIMARY KEY (uuid);'
+  end
+end

--- a/db/migrate/20240728011040_delete_diary_id.rb
+++ b/db/migrate/20240728011040_delete_diary_id.rb
@@ -1,0 +1,5 @@
+class DeleteDiaryId < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :diaries, :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_27_235111) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_28_011040) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "diaries", force: :cascade do |t|
+  create_table "diaries", primary_key: "uuid", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.date "date"
     t.bigint "pose_id", null: false
     t.bigint "user_id", null: false
@@ -28,6 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_27_235111) do
     t.datetime "updated_at", null: false
     t.index ["pose_id"], name: "index_diaries_on_pose_id"
     t.index ["user_id"], name: "index_diaries_on_user_id"
+    t.index ["uuid"], name: "index_diaries_on_uuid", unique: true
   end
 
   create_table "poses", force: :cascade do |t|

--- a/spec/models/diary_spec.rb
+++ b/spec/models/diary_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Diary, type: :model do
 
     context 'when user is logged in' do
       it '設定したすべてのバリデーションが機能しているか' do
-        diary=build(:diary,user: user, pose: pose)
+        diary=build(:diary,user: user, pose: pose, date: date)
         expect(diary).to be_valid
         expect(diary.errors).to be_empty
       end
@@ -43,6 +43,12 @@ RSpec.describe Diary, type: :model do
         diary_of_same_day=build(:diary, user: user, pose: pose, date:date)
         expect(diary_of_same_day).to be_invalid
         expect(diary_of_same_day.errors[:base]).to eq(["今日のDiaryは登録してあります！また明日も頑張りましょう！"])
+      end
+
+      it '当日以外の日でdiaryが登録できない' do
+        diary=build(:diary, date: Date.yesterday)
+        expect(diary).to be_invalid
+        expect(diary.errors[:date]).to eq(["当日分のみ登録できます"]) 
       end
     end
   end   


### PR DESCRIPTION
## 概要

レビュー #165への対応

## やったこと

- [x] DiaryをidからUUIDへ変更
- [x] 当日以外Diaryを記録できないようバリデーション設定

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* DiaryがURLより推測できない（id→UUID）
* 当日以外にDiaryを登録できない

## 動作確認

* ブラウザにて確認(UUIDへの変更)
[![Image from Gyazo](https://i.gyazo.com/0cb9915acd4aa8e396edfdf9bc98b6e5.png)](https://gyazo.com/0cb9915acd4aa8e396edfdf9bc98b6e5)

* コンソールにて当日以外の登録ができないことを確認
[![Image from Gyazo](https://i.gyazo.com/50c6a62358065682692990670afdcfe8.png)](https://gyazo.com/50c6a62358065682692990670afdcfe8)

## 関連Issue
#167 

## その他


