### PR TITLE
ポーズお気に入り機能/viewの実装

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -150,3 +150,10 @@ footer{
   margin-bottom: 0;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
+
+.bookmark-icon {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  font-size: 1.5rem;
+}

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -3,13 +3,13 @@ class BookmarksController < ApplicationController
 
   def create
     @pose = Pose.find(params[:pose_id])
-    current_user.bookmark(@pose) 
-    flash[:notice] = 'お気に入りに追加しました'
+    current_user.bookmark(@pose)
+    flash.now[:notice] = 'お気に入りに追加しました'
   end
 
   def destroy
     @pose = current_user.bookmarks.find(params[:id]).pose
     current_user.unbookmark(@pose)
-    flash[:notice] = 'お気に入りを解除しました'
+    flash.now[:notice] = 'お気に入りを解除しました'
   end
 end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,5 +1,5 @@
 class DiariesController < ApplicationController
-  skip_before_action :authenticate_user!
+  before_action :authenticate_user!
   before_action :set_pose, only: %i[new]
   before_action :check_register_diary, only: %i[new create]
 

--- a/app/views/bookmarks/create.turbo_stream.erb
+++ b/app/views/bookmarks/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "bookmark-button-for-pose-#{@pose.id}" do %>
+  <%= render 'poses/bookmark_buttons', pose: @pose %>
+<% end %>

--- a/app/views/bookmarks/destroy.turbo_stream.erb
+++ b/app/views/bookmarks/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "bookmark-button-for-pose-#{@pose.id}" do %>
+  <%= render 'poses/bookmark_buttons', pose: @pose %>
+<% end %>

--- a/app/views/poses/_bookmark.html.erb
+++ b/app/views/poses/_bookmark.html.erb
@@ -1,0 +1,3 @@
+<%= link_to bookmarks_path(pose_id: @pose.id), id: "bookmark-button-for-pose-#{@pose.id}", remote: true, data: { turbo_method: :post, toggle: "tooltip", placement: "top" }, title: "お気に入りに追加" do %>
+  <i class="fa-regular fa-heart text-danger bookmark-icon"></i>
+<% end %>

--- a/app/views/poses/_bookmark_buttons.html.erb
+++ b/app/views/poses/_bookmark_buttons.html.erb
@@ -1,0 +1,5 @@
+<% if current_user.bookmark?(@pose) %>
+  <%= render 'poses/unbookmark', { pose: @pose } %>
+<% else %>
+  <%= render 'poses/bookmark', { pose: @pose } %>
+<% end %>

--- a/app/views/poses/_pose.html.erb
+++ b/app/views/poses/_pose.html.erb
@@ -1,0 +1,19 @@
+<div class="col-6 col-md-4 col-lg-3 mb-4">
+  <div class="card h-80">
+    <%= link_to pose_path(pose), style: "color: #333333;" do %>
+      <h5 class="card-title mt-5 text-center"><%= pose.japanese_name %></h5>
+    <% end %>
+    <%= image_tag pose.image, class: "card-img-top img-fluid" %>
+    <div class="card-body text-center p-2">
+      <% if current_user.bookmark?(pose) %>
+        <%= link_to bookmark_path(current_user.bookmarks.find_by(pose_id: pose.id)), id: "unbookmark-button-for-pose-#{pose.id}", data: { turbo_method: :delete, toggle: "tooltip", placement: "top" }, title: "お気に入りから削除" do %>
+          <i class="fa-solid fa-heart text-danger bookmark-icon"></i>
+        <% end %>
+      <% else %>
+        <%= link_to bookmarks_path(pose_id: pose.id), id: "bookmark-button-for-pose-#{pose.id}", remote: true, data: { turbo_method: :post, toggle: "tooltip", placement: "top" }, title: "お気に入りに追加" do %>
+          <i class="fa-regular fa-heart text-danger bookmark-icon"></i>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/poses/_unbookmark.html.erb
+++ b/app/views/poses/_unbookmark.html.erb
@@ -1,0 +1,3 @@
+<%= link_to bookmark_path(current_user.bookmarks.find_by(pose_id: @pose.id)), id: "unbookmark-button-for-pose-#{@pose.id}", remote: true,  data: { turbo_method: :delete, toggle: "tooltip", placement: "top" }, title: "お気に入りから削除" do %>
+  <i class="fa-solid fa-heart text-danger bookmark-icon"></i>
+<% end %>

--- a/app/views/poses/bookmarks.html.erb
+++ b/app/views/poses/bookmarks.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:title, "お気に入りポーズ") %>
+<div class="container pt-3">
+  <div class="mt-2 text-center">
+    <h1>お気に入りポーズ</h1>
+    <div class="row mt-5">
+      <div class="col-12">
+        <div class="row">
+          <% if @bookmark_poses.present? %>
+            <% @bookmark_poses.each do |pose| %>
+              <%= render partial: 'pose', locals: { pose: pose } %>
+            <% end %>
+          <% else %>
+            <p>お気に入りのポーズがありません <i class="fa-regular fa-face-sad-tear"></i></p>
+            <br>
+            <p>好きなポーズを見つけてお気に入り登録しよう！</p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/poses/show.html.erb
+++ b/app/views/poses/show.html.erb
@@ -1,7 +1,6 @@
 <% provide(:title, @pose.japanese_name) %>
 <meta name="title" content="<%= yield(:title) %>">
 <div class="container mb-4">
-  <!-- ポーズ名を上部中央に表示 -->
   <div class="row">
     <div class="col-12 text-center mt-4">
       <h1><%= @pose.japanese_name %></h1>
@@ -9,8 +8,12 @@
   </div>
 
   <div class="row mt-4 mb-2">
-    <div class="col-md-6 d-flex align-items-center justify-content-center mb-3">
-      <div class="card">
+    <div class="col-md-6 d-flex align-items-center justify-content-center mb-3 position-relative">
+      <div class="card position-relative">
+        <% if user_signed_in? %>
+          <%= render 'bookmark_buttons', { pose: @pose } %>
+        <% end %>
+        <br>
         <%= image_tag @pose.image, class: "img-fluid fixed-size" %>
       </div>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,6 +15,9 @@
           <%= link_to 'My Diary', diaries_path, class: 'nav-link' %>
         </li>
         <li class='nav-item'>
+          <%= link_to 'お気に入りポーズ', bookmarks_poses_path, class: 'nav-link' %>
+        </li>
+        <li class='nav-item'>
           <%= link_to 'ログアウト', logout_path, class: 'nav-link', data: { turbo_method: :delete } %>
         </li>
       </ul>


### PR DESCRIPTION
## 概要

ブックマーク機能を実装するため、登録ができるviewを作成

## やったこと

- [x] ポーズ詳細カード上部にお気に入りボタン設置(❤）
- [x] お気に入り時❤表示、解除時♡表示
- [x] turboにてお気に入り更新
- [x] ヘッダーにお気に入りボタン設置
- [x] お気に入りポーズ一覧画面作成
- [x] ヘッダーからお気に入りポーズ一覧へ遷移
- [x] lint check修正

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 気に入ったポーズをお気に入り登録できる
* お気に入りポーズを一覧で確認できる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* お気に入り登録
[![Image from Gyazo](https://i.gyazo.com/8ce368eded00cb0c0cfe98dec8ff8335.gif)](https://gyazo.com/8ce368eded00cb0c0cfe98dec8ff8335)

* お気に入り解除
[![Image from Gyazo](https://i.gyazo.com/0afd8bf7d1c75cd2328724d51a2435cc.gif)](https://gyazo.com/0afd8bf7d1c75cd2328724d51a2435cc)

* お気に入り一覧
[![Image from Gyazo](https://i.gyazo.com/29cad0a10da5e71a6a4ccdbe0be03be7.png)](https://gyazo.com/29cad0a10da5e71a6a4ccdbe0be03be7)

## 関連Issue
 #178 #179  #181 

## その他

* 当初お気に入り表示を☆で表す予定だったが、色合い等を鑑みて♡に変更
