### PR TITLE
CSRF対応

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,10 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  OmniAuth.config.allowed_request_methods = [:post, :get]
+  provider :line, ENV.fetch('LINE_KEY', nil), ENV.fetch('LINE_SECRET', nil), {
+    scope: 'profile openid',
+    prompt: 'consent',
+    bot_prompt: 'normal',
+    redirect_uri: 'https://www.yoga-diary-app.com/users/auth/line/callback'
+  }
 end
+
+OmniAuth.config.allowed_request_methods = [:post]


### PR DESCRIPTION
## 概要

エラー対応
```
 WARN -- omniauth: (line)   You are using GET as an allowed request method for OmniAuth. This may leave
  you open to CSRF attacks. As of v2.0.0, OmniAuth by default allows only POST
 ```

## やったこと

* LINE認証時の対応変更


## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし
## できなくなること（ユーザ目線）

* なし
## 動作確認

デプロイ後確認

## 関連Issue
#185 

## その他


