### PR TITLE
修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
         title: :title,
         description: :description,
         type: 'website',
-        url: request.original_url,
+        url: 'https://www.yoga-diary-app.com'
         image: image_url('ogp.png'),
         local: 'ja-JP'
       },

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
         title: :title,
         description: :description,
         type: 'website',
-        url: 'https://www.yoga-diary-app.com'
+        url: 'https://www.yoga-diary-app.com',
         image: image_url('ogp.png'),
         local: 'ja-JP'
       },

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -7,4 +7,5 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   }
 end
 
+OmniAuth.config.logger = Rails.logger
 OmniAuth.config.allowed_request_methods = [:post]


### PR DESCRIPTION
## 概要

エラー対応
```
 WARN -- omniauth: (line)   You are using GET as an allowed request method for OmniAuth. This may leave
  you open to CSRF attacks. As of v2.0.0, OmniAuth by default allows only POST
 ```

## やったこと

* LINE認証時の対応変更

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

デプロイ後確認

## 関連Issue
#185  #186

## その他


