### PR TITLE
微調整

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -39,7 +39,7 @@ class DiariesController < ApplicationController
     if @diary.update(diary_params)
       redirect_to diary_path(@diary), notice: '編集しました'
     else
-      Rails.logger.debug "エラー内容: #{@diary.errors.full_messages.join(', ')}"
+      Rails.logger.debug { "エラー内容: #{@diary.errors.full_messages.join(', ')}" }
       flash.now[:alert] = '編集できませんでした'
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -39,6 +39,7 @@ class DiariesController < ApplicationController
     if @diary.update(diary_params)
       redirect_to diary_path(@diary), notice: '編集しました'
     else
+      Rails.logger.debug "エラー内容: #{@diary.errors.full_messages.join(', ')}"
       flash.now[:alert] = '編集できませんでした'
       render :edit, status: :unprocessable_entity
     end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -16,17 +16,17 @@ class Diary < ApplicationRecord
 
   def only_one_diary_per_day
     existing_diary = Diary.where(user_id: user_id, date: date).where.not(uuid: uuid).exists?
-    Rails.logger.debug "Existing diary: #{existing_diary}"
-    Rails.logger.debug "Validation errors: #{errors.full_messages.join(', ')}"
+    Rails.logger.debug { "Existing diary: #{existing_diary}" }
+    Rails.logger.debug { "Validation errors: #{errors.full_messages.join(', ')}" }
 
     if existing_diary
       errors.add(:base, '今日のDiaryは登録してあります！また明日も頑張りましょう！')
     end
   end
-  
 
   def register_today
     return unless date != Time.zone.today
+
     errors.add(:date, '当日分のみ登録できます')
   end
 end

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -15,7 +15,7 @@
   </div>
 
   <div class="mb-3">
-    <%= form.label :compatibility, 'ポーズとの相性', class: 'form-label' %>
+    <%= form.label :compatibility, 'ポーズの完成度', class: 'form-label' %>
     <div class="d-flex justify-content-start flex-wrap ms-3 gap-3">
       <%= enum_radio_buttons(form, :compatibility, Diary.compatibilities) %>
     </div>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -19,7 +19,7 @@
 
           <div class="row mb-3">
             <div class="col">
-              <strong class="me-3">ポーズとの相性</strong>
+              <strong class="me-3">ポーズの完成度</strong>
               <p class="form-control-plaintext ms-5">
                 <%= enum_icon(@diary.compatibility) %>
               </p>

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -42,7 +42,7 @@
               </span>
               <h4 class="my-3">Yoga実践</h4>
             </div>
-            <p class="text-muted text-start mt-3">Startボタンを押すと今日のYogaポーズを表示します<br>やり方にそってポーズをしてみましょう<br>もちろんやってみたいポーズを見つけたらイラストをクリック！</p>
+            <p class="text-muted text-start mt-3">【さっそくはじめる】を押すと今日のYogaポーズを表示します<br>やり方にそってポーズをしてみましょう<br>もちろんやってみたいポーズを見つけたらイラストをクリック！</p>
           </div>
         </div>
       </div>
@@ -68,7 +68,7 @@
               </span>
               <h4 class="my-3">通知</h4>
             </div>
-            <p class="text-muted text-start mt-3">ついつい忘れちゃう場合はLINE通知を設定してYogaポーズを受け取りましょう<br>My Diaryページで友達追加して設定できます</p>
+            <p class="text-muted text-start mt-3">ついつい忘れちゃう場合はLINE通知を設定してYogaポーズを受け取りましょう！<br>My Diaryページの？ボタンを押して友達追加し通知設定をオンにしてください</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要

不具合修正

## やったこと

- [x] Diaryの【ポーズとの相性】を【ポーズの完成度】へ変更
- [x] トップページのこのアプリでできることの文言変更
　　- 【startボタン 】を【さっそくはじめる】に変更
　　- 通知のイラスト変更
- [x] diaryの編集を当日以外もできるように修正

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 使い方の説明と実際の文言が統一され、わかりやすくなる
* Diaryの編集が当日以外も可能になる

## できなくなること（ユーザ目線）

* なし

## 動作確認

[![Image from Gyazo](https://i.gyazo.com/7be4407e1b55108404b6330996f6ee50.png)](https://gyazo.com/7be4407e1b55108404b6330996f6ee50)

[![Image from Gyazo](https://i.gyazo.com/6c27fb8f31cc64ddfa574097b559ac47.gif)](https://gyazo.com/6c27fb8f31cc64ddfa574097b559ac47)

## 関連Issue


## その他


